### PR TITLE
Add api routing

### DIFF
--- a/config/routing.map
+++ b/config/routing.map
@@ -8,6 +8,7 @@
 ^/api_health(\/)?$  be_api
 ^/upload/v2(\/)?$  be_api
 ^/upload/v4(\/)?$  be_api
+^/api(\/.*)?$  be_api
 ^/upload/(gh|github|ghe|github_enterprise|bb|bitbucket|bbs|bitbucket_server|gl|gitlab|gle|gitlab_enterprise)(\/.*)?$  be_api
 ^/profiling(\/.*)?$  be_ia
 ^/(.*)/(.*)/(.*)/branch/(?P<branch>.+)/(graph|graphs)/badge.svg be_api


### PR DESCRIPTION
Routes `/api*` on to the Codecov API.