### PR TITLE
feat: Expand logout matcher to support no provider endpoint

### DIFF
--- a/config/codecov.map
+++ b/config/codecov.map
@@ -16,7 +16,7 @@
 ^/(.*)/(.*)/(.*)/branch/(?P<branch>.+)/(graph|graphs)/badge.svg be_api
 ^/.*/.*/.*/(graph|graphs)/badge.svg be_api
 ^/login/(gh|github|ghe|github_enterprise|bb|bitbucket|bbs|bitbucket_server|gl|gitlab|gle|gitlab_enterprise|okta|sentry) be_api
-^/logout((\/)(gh|github|ghe|github_enterprise|bb|bitbucket|bbs|bitbucket_server|gl|gitlab|gle|gitlab_enterprise|okta|sentry)?)?$
+^/logout((\/)(gh|github|ghe|github_enterprise|bb|bitbucket|bbs|bitbucket_server|gl|gitlab|gle|gitlab_enterprise|okta|sentry)?)? be_api
 ^/.*/.*/.*/pull/(?P<pullid>[^/]+)/(graph|graphs)/(?P<graph>tree|icicle|sunburst|commits).svg be_api
 ^/.*/.*/.*/branch/(?P<branch>[^/].+)/(graph|graphs)/(?P<graph>tree|icicle|sunburst|commits).svg be_api
 ^/.*/.*/.*/(graph|graphs)/(?P<graph>tree|icicle|sunburst|commits).svg be_api

--- a/config/codecov.map
+++ b/config/codecov.map
@@ -16,7 +16,7 @@
 ^/(.*)/(.*)/(.*)/branch/(?P<branch>.+)/(graph|graphs)/badge.svg be_api
 ^/.*/.*/.*/(graph|graphs)/badge.svg be_api
 ^/login/(gh|github|ghe|github_enterprise|bb|bitbucket|bbs|bitbucket_server|gl|gitlab|gle|gitlab_enterprise|okta|sentry) be_api
-^/logout((\/)(gh|github|ghe|github_enterprise|bb|bitbucket|bbs|bitbucket_server|gl|gitlab|gle|gitlab_enterprise|okta|sentry)?)? be_api
+^/logout(/(gh|github|ghe|github_enterprise|bb|bitbucket|bbs|bitbucket_server|gl|gitlab|gle|gitlab_enterprise|okta|sentry)?)? be_api
 ^/.*/.*/.*/pull/(?P<pullid>[^/]+)/(graph|graphs)/(?P<graph>tree|icicle|sunburst|commits).svg be_api
 ^/.*/.*/.*/branch/(?P<branch>[^/].+)/(graph|graphs)/(?P<graph>tree|icicle|sunburst|commits).svg be_api
 ^/.*/.*/.*/(graph|graphs)/(?P<graph>tree|icicle|sunburst|commits).svg be_api

--- a/config/codecov.map
+++ b/config/codecov.map
@@ -16,7 +16,7 @@
 ^/(.*)/(.*)/(.*)/branch/(?P<branch>.+)/(graph|graphs)/badge.svg be_api
 ^/.*/.*/.*/(graph|graphs)/badge.svg be_api
 ^/login/(gh|github|ghe|github_enterprise|bb|bitbucket|bbs|bitbucket_server|gl|gitlab|gle|gitlab_enterprise|okta|sentry) be_api
-^/logout/(gh|github|ghe|github_enterprise|bb|bitbucket|bbs|bitbucket_server|gl|gitlab|gle|gitlab_enterprise|okta|sentry) be_api
+^/logout((\/)(gh|github|ghe|github_enterprise|bb|bitbucket|bbs|bitbucket_server|gl|gitlab|gle|gitlab_enterprise|okta|sentry)?)?$
 ^/.*/.*/.*/pull/(?P<pullid>[^/]+)/(graph|graphs)/(?P<graph>tree|icicle|sunburst|commits).svg be_api
 ^/.*/.*/.*/branch/(?P<branch>[^/].+)/(graph|graphs)/(?P<graph>tree|icicle|sunburst|commits).svg be_api
 ^/.*/.*/.*/(graph|graphs)/(?P<graph>tree|icicle|sunburst|commits).svg be_api


### PR DESCRIPTION
Updates logout endpoint matcher to catch `/logout` and `/logout/`.

Related to recent change to logout endpoint, testing locally with gateway revealed this was broken.