### PR TITLE
fix minio path mapping

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -92,13 +92,13 @@ _start_haproxy() {
   BACKENDS="-f /etc/haproxy/1-backends.conf"
   envsubst < /etc/haproxy/1-backends.conf.template > /etc/haproxy/1-backends.conf
   MINIO_FILE=""
-  if [ "$CODECOV_GATEWAY_MINIO_ENABLED" ]; then
+  if [ "$CODECOV_GATEWAY_MINIO_ENABLED" ] && [ "$routing_map" != "proxy" ]; then
       echo 'Codecov gateway minio enabled'
       if [ $CODECOV_MINIO_SCHEME = "https" ]; then
           export CODECOV_MINIO_SSL_FLAG=$ssl_string
       fi
       envsubst < /etc/haproxy/1-minio.conf.template > /etc/haproxy/1-minio.conf
-      cat /etc/haproxy/minio.map >> /etc/haproxy/routing.map
+      cat /etc/haproxy/minio.map >> /etc/haproxy/codecov.map
       MINIO_FILE="-f /etc/haproxy/1-minio.conf"
   fi
   echo "Starting haproxy"


### PR DESCRIPTION
this fixes an issue introduced in https://github.com/codecov/codecov-gateway/commit/220d850133a3688002c38307507493988f8d4829. In that commit the routing map file name was changed from `routing.map` to `codecov.map`, but that was never changed for minio. Therefore accesses to `<host>/archive` are not correctly proxied to minio, but rather to the default backend. This causes uploads to the storage to fail, after this change the upload works successfully.

Old:
```
debug - 2024-06-27 11:06:48,946 -- Upload request to Codecov complete. --- {"response": {"external_id": "...", "created_at": "2024-06-27T11:06:48.824828Z", "raw_upload_location": "https://<host>/archive/v4/raw/2024-06-27/7A629CCD.....", "state": "", "provider": null, "upload_type": "uploaded", "url": "...", "ci_url": "...", "flags": [], "env": {}, "name": "...", "job_code": "Test & Coverage"}}
debug - 2024-06-27 11:06:48,947 -- Sending upload to storage
warning - 2024-06-27 11:09:03,464 -- Request failed. Retrying --- {"retry": 0}
warning - 2024-06-27 11:11:18,632 -- Request failed. Retrying --- {"retry": 1}
warning - 2024-06-27 11:13:33,800 -- Request failed. Retrying --- {"retry": 2}
```

New:
```
debug - 2024-06-27 12:53:31,659 -- Upload request to Codecov complete. --- {"response": {"external_id": "...", "created_at": "2024-06-27T12:53:31.496127Z", "raw_upload_location": "https://<host>/archive/v4/raw/2024-06-27/62CD7E...", "state": "", "provider": null, "upload_type": "uploaded", "url": "...", "ci_url": "...", "flags": [], "env": {}, "name": "...", "job_code
debug - 2024-06-27 12:53:31,659 -- Sending upload to storage
info - 2024-06-27 12:53:32,088 -- Process Upload complete
```